### PR TITLE
[BALDE-14] Matrix 4x4 (#20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,7 @@ add_compile_options(
         -Wpedantic -Wconversion -Wnull-dereference
         -Wdouble-promotion -Wduplicated-cond
         -Wduplicated-branches
-        -Wlogical-op -fsanitize=leak
-)
+        -Wlogical-op -fsanitize=leak)
 
 add_definitions(-D_LINUX)
 
@@ -41,7 +40,11 @@ add_library(bald_engine
         src/utils/file_manager.cpp
         src/utils/split_string.cpp
         src/input/input_manager.cpp
-        src/Log.cpp)
+        src/Log.cpp
+        src/math/vec2.cpp
+        src/math/vec3.cpp
+        src/math/vec4.cpp
+        src/math/mat4.cpp)
 
 link_directories(${CMAKE_SOURCE_DIR}/vendor/glad/bin)
 
@@ -53,9 +56,9 @@ if (APPLE)
             "-framework OpenGL"
             "-framework IOKit"
             "-framework CoreVideo")
-else()
+else ()
     target_link_libraries(bald_engine glad glfw3 GL X11 Xi Xrandr Xxf86vm Xinerama Xcursor rt m pthread dl)
-endif()
+endif ()
 
 #### END CONFIG/DEFINITIONS
 

--- a/src/math/mat4.cpp
+++ b/src/math/mat4.cpp
@@ -1,0 +1,145 @@
+//
+// Created by blinku on 07.02.19.
+//
+
+#include "mat4.h"
+
+namespace Bald::Math {
+
+    void Mat4::Inverse() noexcept {
+            Mat4 copy = *this;
+
+            m_MatrixElements[0] =   copy.m_MatrixElements[5]  * copy.m_MatrixElements[10] * copy.m_MatrixElements[15] -
+                                    copy.m_MatrixElements[5]  * copy.m_MatrixElements[11] * copy.m_MatrixElements[14] -
+                                    copy.m_MatrixElements[9]  * copy.m_MatrixElements[6]  * copy.m_MatrixElements[15] +
+                                    copy.m_MatrixElements[9]  * copy.m_MatrixElements[7]  * copy.m_MatrixElements[14] +
+                                    copy.m_MatrixElements[13] * copy.m_MatrixElements[6]  * copy.m_MatrixElements[11] -
+                                    copy.m_MatrixElements[13] * copy.m_MatrixElements[7]  * copy.m_MatrixElements[10];
+
+            m_MatrixElements[4] =  -copy.m_MatrixElements[4]  * copy.m_MatrixElements[10] * copy.m_MatrixElements[15] +
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[11] * copy.m_MatrixElements[14] +
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[6]  * copy.m_MatrixElements[15] -
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[7]  * copy.m_MatrixElements[14] -
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[6]  * copy.m_MatrixElements[11] +
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[7]  * copy.m_MatrixElements[10];
+
+            m_MatrixElements[8] =   copy.m_MatrixElements[4]  * copy.m_MatrixElements[9]  * copy.m_MatrixElements[15] -
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[11] * copy.m_MatrixElements[13] -
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[5]  * copy.m_MatrixElements[15] +
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[7]  * copy.m_MatrixElements[13] +
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[5]  * copy.m_MatrixElements[11] -
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[7]  * copy.m_MatrixElements[9];
+
+            m_MatrixElements[12] = -copy.m_MatrixElements[4]  * copy.m_MatrixElements[9]  * copy.m_MatrixElements[14] +
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[10] * copy.m_MatrixElements[13] +
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[5]  * copy.m_MatrixElements[14] -
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[6]  * copy.m_MatrixElements[13] -
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[5]  * copy.m_MatrixElements[10] +
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[6]  * copy.m_MatrixElements[9];
+
+            m_MatrixElements[1] =  -copy.m_MatrixElements[1]  * copy.m_MatrixElements[10] * copy.m_MatrixElements[15] +
+                                    copy.m_MatrixElements[1]  * copy.m_MatrixElements[11] * copy.m_MatrixElements[14] +
+                                    copy.m_MatrixElements[9]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[15] -
+                                    copy.m_MatrixElements[9]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[14] -
+                                    copy.m_MatrixElements[13] * copy.m_MatrixElements[2]  * copy.m_MatrixElements[11] +
+                                    copy.m_MatrixElements[13] * copy.m_MatrixElements[3]  * copy.m_MatrixElements[10];
+
+            m_MatrixElements[5] =   copy.m_MatrixElements[0]  * copy.m_MatrixElements[10] * copy.m_MatrixElements[15] -
+                                    copy.m_MatrixElements[0]  * copy.m_MatrixElements[11] * copy.m_MatrixElements[14] -
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[15] +
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[14] +
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[2]  * copy.m_MatrixElements[11] -
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[3]  * copy.m_MatrixElements[10];
+
+            m_MatrixElements[9] =  -copy.m_MatrixElements[0]  * copy.m_MatrixElements[9]  * copy.m_MatrixElements[15] +
+                                    copy.m_MatrixElements[0]  * copy.m_MatrixElements[11] * copy.m_MatrixElements[13] +
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[1]  * copy.m_MatrixElements[15] -
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[13] -
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[1]  * copy.m_MatrixElements[11] +
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[3]  * copy.m_MatrixElements[9];
+
+            m_MatrixElements[13] =  copy.m_MatrixElements[0]  * copy.m_MatrixElements[9]  * copy.m_MatrixElements[14] -
+                                    copy.m_MatrixElements[0]  * copy.m_MatrixElements[10] * copy.m_MatrixElements[13] -
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[1]  * copy.m_MatrixElements[14] +
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[13] +
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[1]  * copy.m_MatrixElements[10] -
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[2]  * copy.m_MatrixElements[9];
+
+            m_MatrixElements[2] =   copy.m_MatrixElements[1]  * copy.m_MatrixElements[6]  * copy.m_MatrixElements[15] -
+                                    copy.m_MatrixElements[1]  * copy.m_MatrixElements[7]  * copy.m_MatrixElements[14] -
+                                    copy.m_MatrixElements[5]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[15] +
+                                    copy.m_MatrixElements[5]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[14] +
+                                    copy.m_MatrixElements[13] * copy.m_MatrixElements[2]  * copy.m_MatrixElements[7]  -
+                                    copy.m_MatrixElements[13] * copy.m_MatrixElements[3]  * copy.m_MatrixElements[6];
+
+            m_MatrixElements[6] =  -copy.m_MatrixElements[0]  * copy.m_MatrixElements[6]  * copy.m_MatrixElements[15] +
+                                    copy.m_MatrixElements[0]  * copy.m_MatrixElements[7]  * copy.m_MatrixElements[14] +
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[15] -
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[14] -
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[2]  * copy.m_MatrixElements[7]  +
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[3]  * copy.m_MatrixElements[6];
+
+            m_MatrixElements[10] =  copy.m_MatrixElements[0]  * copy.m_MatrixElements[5]  * copy.m_MatrixElements[15] -
+                                    copy.m_MatrixElements[0]  * copy.m_MatrixElements[7]  * copy.m_MatrixElements[13] -
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[1]  * copy.m_MatrixElements[15] +
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[13] +
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[1]  * copy.m_MatrixElements[7]  -
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[3]  * copy.m_MatrixElements[5];
+
+            m_MatrixElements[14] = -copy.m_MatrixElements[0]  * copy.m_MatrixElements[5]  * copy.m_MatrixElements[14] +
+                                    copy.m_MatrixElements[0]  * copy.m_MatrixElements[6]  * copy.m_MatrixElements[13] +
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[1]  * copy.m_MatrixElements[14] -
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[13] -
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[1]  * copy.m_MatrixElements[6]  +
+                                    copy.m_MatrixElements[12] * copy.m_MatrixElements[2]  * copy.m_MatrixElements[5];
+
+            m_MatrixElements[3] =  -copy.m_MatrixElements[1]  * copy.m_MatrixElements[6]  * copy.m_MatrixElements[11] +
+                                    copy.m_MatrixElements[1]  * copy.m_MatrixElements[7]  * copy.m_MatrixElements[10] +
+                                    copy.m_MatrixElements[5]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[11] -
+                                    copy.m_MatrixElements[5]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[10] -
+                                    copy.m_MatrixElements[9]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[7]  +
+                                    copy.m_MatrixElements[9]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[6];
+
+            m_MatrixElements[7] =   copy.m_MatrixElements[0]  * copy.m_MatrixElements[6]  * copy.m_MatrixElements[11] -
+                                    copy.m_MatrixElements[0]  * copy.m_MatrixElements[7]  * copy.m_MatrixElements[10] -
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[11] +
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[10] +
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[7]  -
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[6];
+
+            m_MatrixElements[11] = -copy.m_MatrixElements[0]  * copy.m_MatrixElements[5]  * copy.m_MatrixElements[11] +
+                                    copy.m_MatrixElements[0]  * copy.m_MatrixElements[7]  * copy.m_MatrixElements[9]  +
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[1]  * copy.m_MatrixElements[11] -
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[9]  -
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[1]  * copy.m_MatrixElements[7]  +
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[3]  * copy.m_MatrixElements[5];
+
+            m_MatrixElements[15] =  copy.m_MatrixElements[0]  * copy.m_MatrixElements[5]  * copy.m_MatrixElements[10] -
+                                    copy.m_MatrixElements[0]  * copy.m_MatrixElements[6]  * copy.m_MatrixElements[9]  -
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[1]  * copy.m_MatrixElements[10] +
+                                    copy.m_MatrixElements[4]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[9]  +
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[1]  * copy.m_MatrixElements[6]  -
+                                    copy.m_MatrixElements[8]  * copy.m_MatrixElements[2]  * copy.m_MatrixElements[5];
+
+            float det = copy.m_MatrixElements[0] * m_MatrixElements[0] +
+                        copy.m_MatrixElements[1] * m_MatrixElements[4] +
+                        copy.m_MatrixElements[2] * m_MatrixElements[8] +
+                        copy.m_MatrixElements[3] * m_MatrixElements[12];
+
+            if(det == 0) {
+                    CORE_LOG_WARN("Matrix determinant equals 0! Returning identity matrix!");
+                    *this = Identity();
+                    return;
+            }
+
+            for (int i = 0; i < 16; ++i)
+                    m_MatrixElements[i] /= det;
+    }
+
+    Mat4 Mat4::Inverse(const Mat4& matrix) noexcept {
+            Mat4 copy = matrix;
+            copy.Inverse();
+            return copy;
+    }
+
+}

--- a/src/math/mat4.h
+++ b/src/math/mat4.h
@@ -1,0 +1,562 @@
+//
+// Created by blinku on 05.02.19.
+//
+
+#pragma once
+
+#include "pch.h"
+#include "math.h"
+#include "utils/utils.h"
+#include "utils/math_utils.h"
+#include <cmath>
+
+
+
+/**
+ * @class Mat4
+ * @brief 4x4 matrix class, column major implementation
+ */
+
+namespace Bald::Math {
+    class Mat4 {
+    public:
+        /**
+        * @fn               Mat4
+        * @brief            constructor
+        * @param [float]    diagonal -> diagonal value which will be used to construct matrix
+        */
+        explicit constexpr Mat4(float diagonal = 1.0f);
+
+        /**
+        * @fn               Mat4
+        * @brief            constructor
+        * @param [float*]   data -> pointer to an array of floats, which will be used to construct matrix
+        */
+        explicit constexpr Mat4(float* data);
+
+        /**
+        * @fn               ~Mat4
+        * @brief            trivial destructor
+        */
+        ~Mat4() = default;
+
+        /**
+        * @fn               Det
+        * @brief            calculates determinant of the matrix
+        * @return [float]   determinant
+        */
+        [[nodiscard]] constexpr float Det() const noexcept;
+
+        /**
+        * @fn               Transpose
+        * @brief            transposes the matrix
+        */
+        constexpr void Transpose() noexcept;
+
+        /**
+        * @fn                   Transpose
+        * @brief                calculates transpose matrix of a given matrix
+        * @param [const Mat4&]  matrix -> const reference to Mat4
+        * @return [Mat4]        transposed matrix
+        */
+        [[nodiscard]] constexpr static Mat4 Transpose(const Mat4& matrix) noexcept;
+
+        /**
+        * @fn               Inverse
+        * @brief            inverses the matrix
+        */
+        void Inverse() noexcept;
+
+        /**
+        * @fn                   Inverse
+        * @brief                calculates inverse matrix
+        * @param [const Mat4&]  matrix -> matrix which we want to get inverse of
+        * @return [Mat4]        inversed matrix
+        */
+        [[nodiscard]] static Mat4 Inverse(const Mat4& matrix) noexcept;
+
+        /**
+        * @fn                   Identity
+        * @brief                constructs identity matrix
+        * @return [Mat4]        identity matrix
+        */
+        [[nodiscard]] constexpr static Mat4 Identity() noexcept;
+
+        /**
+        * @fn                   Translation
+        * @brief                constructs translation matrix
+        * @param [const Vec3&]  translation -> vector by which the matrix will translate
+        * @return [Mat4]        translation matrix
+        */
+        [[nodiscard]] constexpr static Mat4 Translation(const Vec3& translation) noexcept;
+
+        /**
+        * @fn                   Scale
+        * @brief                constructs scale matrix
+        * @param [const Vec3&]  scale -> vector by which the matrix will scale
+        * @return [Mat4]        scale matrix
+        */
+        [[nodiscard]] constexpr static Mat4 Scale(const Vec3& scale) noexcept;
+
+        /**
+        * @fn                   Rotation
+        * @brief                constructs rotation matrix
+        * @param [float]        angle -> angle in degrees by which the matrix will rotate
+        * @param [const Vec3&]  axis -> axis around which the matrix will rotate
+        * @return [Mat4]        rotation matrix
+        */
+        [[nodiscard]] constexpr static Mat4 Rotation(float angle, const Vec3& axis) noexcept;
+
+        /**
+        * @fn                   LookAt
+        * @brief                constructs look at matrix
+        * @param [const Vec3&]  eye -> eye position in world space
+        * @param [const Vec3&]  center -> position of thing we want to look at
+        * @param [const Vec3&]  up -> up vector of e.g. camera (not world up!)
+        * @return [Mat4]        look at matrix
+        */
+        [[nodiscard]] constexpr static Mat4 LookAt(const Vec3& eye, const Vec3& center, const Vec3& up);
+
+        /**
+        * @fn                   OrthogonalProjection
+        * @brief                constructs orthogonal projection matrix
+        * @param [float]        lightSource -> the point towards which we project
+        * @param [float]        normal -> plane's normal vector
+        * @param [float]        offset -> how much the plane is moved from the center (0,0,0)
+        * @return [Mat4]        orthogonal projection matrix
+        */
+        [[nodiscard]] constexpr static Mat4 OrthogonalProjection(const Vec3& lightSource, const Vec3& normal, float offset) noexcept;
+
+        /**
+        * @fn                   Orthographic
+        * @brief                constructs orthographic matrix
+        * @param [float]        left -> left screen space coordinate
+        * @param [float]        right -> right screen space coordinate
+        * @param [float]        bottom -> bottom screen space coordinate
+        * @param [float]        top -> top screen space coordinate
+        * @param [float]        near -> near screen space coordinate
+        * @param [float]        far -> far screen space coordinate
+        * @return [Mat4]        orthographic matrix
+        */
+        [[nodiscard]] constexpr static Mat4 Orthographic(float left, float right, float bottom, float top, float near, float far) noexcept;
+
+        /**
+        * @fn                   Perspective
+        * @brief                constructs perspective matrix
+        * @param [float]        fov -> field of view (vertical)
+        * @param [float]        aspectRatio -> window's aspect ratio
+        * @param [float]        near -> near screen space coordinate
+        * @param [float]        far -> far screen space coordinate
+        * @return [Mat4]        perspective matrix
+        */
+        [[nodiscard]] constexpr static Mat4 Perspective(float fov, float aspectRatio, float near, float far) noexcept;
+
+        /**
+        * @fn                   operator+
+        * @brief                adds two matrices
+        * @param [const Mat4&]  other -> matrix which we add to our current matrix
+        * @return [Mat4]        sum of two matrices
+        */
+        [[nodiscard]] constexpr Mat4 operator+(const Mat4& other) const noexcept;
+
+        /**
+        * @fn                   operator-
+        * @brief                subtracts two matrices
+        * @param [const Mat4&]  other -> matrix which we subtract to our current matrix
+        * @return [Mat4]        difference of two matrices
+        */
+        [[nodiscard]] constexpr Mat4 operator-(const Mat4& other) const noexcept;
+
+        /**
+        * @fn                   operator*
+        * @brief                multiplies matrix by a scalar
+        * @param [float]        scalar -> number by which the matrix will be multiplied
+        * @return [Mat4]        product of scalar and matrix
+        */
+        [[nodiscard]] constexpr Mat4 operator*(float scalar) const noexcept;
+
+        /**
+        * @fn                   operator*
+        * @brief                multiplies two matrices
+        * @param [const Mat4&]  other -> matrix by which we multiply our current matrix
+        * @return [Mat4]        product of two matrices
+        */
+        [[nodiscard]] constexpr Mat4 operator*(const Mat4& other) const noexcept;
+
+        /**
+        * @fn                   operator*
+        * @brief                multiplies matrix by vector
+        * @param [const Vec4&]  other -> vector by which we multiply the matrix
+        * @return [Vec4]        product of matrix and vector
+        */
+        [[nodiscard]] constexpr Vec4 operator*(const Vec4& other) const noexcept;
+
+        /**
+        * @fn                   operator*
+        * @brief                multiplies matrix by vector
+        * @param [const Vec3&]  other -> vector by which we multiply the matrix
+        * @return [Vec4]        product of matrix and vector
+        */
+        [[nodiscard]] constexpr Vec4 operator*(const Vec3& other) const noexcept;
+
+        /**
+        * @fn                   operator==
+        * @brief                checks if two matrices are the same
+        * @param [const Mat4&]  other -> matrix with which we check identity
+        * @return [bool]        true or false
+        */
+        [[nodiscard]] constexpr bool operator==(const Mat4& other) const noexcept;
+
+        /**
+        * @fn                   operator!=
+        * @brief                checks if two matrices are different
+        * @param [const Mat4&]  other -> matrix with which we check identity
+        * @return [bool]        true or false
+        */
+        [[nodiscard]] constexpr bool operator!=(const Mat4& other) const noexcept;
+
+        /**
+        * @fn                   operator+=
+        * @brief                adds two matrices
+        * @param [const Mat4&]  other -> matrix which we add to our current matrix
+        * @return [Mat4&]       sum of two matrices
+        */
+        constexpr Mat4& operator+=(const Mat4& other) noexcept;
+
+        /**
+        * @fn                   operator-=
+        * @brief                subtracts two matrices
+        * @param [const Mat4&]  other -> matrix which we subtract to our current matrix
+        * @return [Mat4&]       difference of two matrices
+        */
+        constexpr Mat4& operator-=(const Mat4& other) noexcept;
+
+        /**
+        * @fn                   operator*=
+        * @brief                multiplies matrix by a scalar
+        * @param [float]        scalar -> number by which the matrix will be multiplied
+        * @return [Mat4]        product of scalar and matrix
+        */
+        constexpr Mat4& operator*=(float scalar) noexcept;
+
+        /**
+        * @fn                   operator*=
+        * @brief                multiplies two matrices
+        * @param [const Mat4&]  other -> matrix by which we multiply our current matrix
+        * @return [Mat4&]       product of two matrices
+        */
+        constexpr Mat4& operator*=(const Mat4& other) noexcept;
+
+        /**
+        * @fn                   operator*
+        * @brief                multiplies matrix by a scalar
+        * @param [float]        scalar -> number by which the matrix will be multiplied
+        * @param [const Mat4&]  other -> matrix which we multiply
+        * @return [Mat4]        product of scalar and matrix
+        */
+        friend constexpr Mat4 operator*(float scalar, const Mat4& other) noexcept;
+
+        /**
+         * @fn                          operator[]
+         * @brief                       returns column at given index
+         * @param [int]                 index -> index of a column which you want to retrieve
+         * @return [const Vec4&]        column in a form of Vec4
+         */
+        [[nodiscard]] constexpr const Vec4& operator[](int index) const noexcept;
+    private:
+        union { /**< union for optimized elements access and elements interpretation*/
+            std::array<float, 16> m_MatrixElements; /**< matrix elements are kept in an array of floats*/
+            Vec4 m_MatrixColumns[4];                /**< matrix elements are kept in an array of Vec4s */
+        };
+
+    }; // END OF CLASS Mat4
+
+    constexpr Mat4::Mat4(float diagonal) : m_MatrixElements{0.0f} {
+        m_MatrixElements[0 + 0 * 4] = diagonal;
+        m_MatrixElements[1 + 1 * 4] = diagonal;
+        m_MatrixElements[2 + 2 * 4] = diagonal;
+        m_MatrixElements[3 + 3 * 4] = diagonal;
+    }
+
+    constexpr Mat4::Mat4(float* data) : m_MatrixElements{0.0f} {
+        std::memcpy(m_MatrixElements.begin(), data, 16 * sizeof(m_MatrixElements[0]));
+    }
+
+    constexpr float Mat4::Det() const noexcept {
+        float minors[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+
+        minors[0] =  m_MatrixElements[5]  * m_MatrixElements[10] * m_MatrixElements[15] -
+                     m_MatrixElements[5]  * m_MatrixElements[11] * m_MatrixElements[14] -
+                     m_MatrixElements[9]  * m_MatrixElements[6]  * m_MatrixElements[15] +
+                     m_MatrixElements[9]  * m_MatrixElements[7]  * m_MatrixElements[14] +
+                     m_MatrixElements[13] * m_MatrixElements[6]  * m_MatrixElements[11] -
+                     m_MatrixElements[13] * m_MatrixElements[7]  * m_MatrixElements[10];
+
+        minors[1] = -m_MatrixElements[4]  * m_MatrixElements[10] * m_MatrixElements[15] +
+                     m_MatrixElements[4]  * m_MatrixElements[11] * m_MatrixElements[14] +
+                     m_MatrixElements[8]  * m_MatrixElements[6]  * m_MatrixElements[15] -
+                     m_MatrixElements[8]  * m_MatrixElements[7]  * m_MatrixElements[14] -
+                     m_MatrixElements[12] * m_MatrixElements[6]  * m_MatrixElements[11] +
+                     m_MatrixElements[12] * m_MatrixElements[7]  * m_MatrixElements[10];
+
+        minors[2] =  m_MatrixElements[4]  * m_MatrixElements[9]  * m_MatrixElements[15] -
+                     m_MatrixElements[4]  * m_MatrixElements[11] * m_MatrixElements[13] -
+                     m_MatrixElements[8]  * m_MatrixElements[5]  * m_MatrixElements[15] +
+                     m_MatrixElements[8]  * m_MatrixElements[7]  * m_MatrixElements[13] +
+                     m_MatrixElements[12] * m_MatrixElements[5]  * m_MatrixElements[11] -
+                     m_MatrixElements[12] * m_MatrixElements[7]  * m_MatrixElements[9];
+
+        minors[3] = -m_MatrixElements[4]  * m_MatrixElements[9]  * m_MatrixElements[14] +
+                     m_MatrixElements[4]  * m_MatrixElements[10] * m_MatrixElements[13] +
+                     m_MatrixElements[8]  * m_MatrixElements[5]  * m_MatrixElements[14] -
+                     m_MatrixElements[8]  * m_MatrixElements[6]  * m_MatrixElements[13] -
+                     m_MatrixElements[12] * m_MatrixElements[5]  * m_MatrixElements[10] +
+                     m_MatrixElements[12] * m_MatrixElements[6]  * m_MatrixElements[9];
+
+        return m_MatrixElements[0] * minors[0] + m_MatrixElements[1] * minors[1] + m_MatrixElements[2] * minors[2] + m_MatrixElements[3] * minors[3];
+    }
+
+    constexpr void Mat4::Transpose() noexcept {
+        Bald::Utils::ConstexprSwap(m_MatrixElements[1],  m_MatrixElements[4]);
+        Bald::Utils::ConstexprSwap(m_MatrixElements[2],  m_MatrixElements[8]);
+        Bald::Utils::ConstexprSwap(m_MatrixElements[3],  m_MatrixElements[12]);
+        Bald::Utils::ConstexprSwap(m_MatrixElements[6],  m_MatrixElements[9]);
+        Bald::Utils::ConstexprSwap(m_MatrixElements[7],  m_MatrixElements[13]);
+        Bald::Utils::ConstexprSwap(m_MatrixElements[11], m_MatrixElements[14]);
+    }
+
+    constexpr Mat4 Mat4::Transpose(const Mat4& matrix) noexcept {
+        Mat4 copy = matrix;
+        copy.Transpose();
+        return copy;
+    }
+
+    constexpr Mat4 Mat4::Identity() noexcept {
+        return Mat4(1.0f);
+    }
+
+    constexpr Mat4 Mat4::Translation(const Vec3& translation) noexcept {
+        Mat4 result(1.0f);
+
+        result.m_MatrixElements[0 + 3 * 4] = translation.GetX();
+        result.m_MatrixElements[1 + 3 * 4] = translation.GetY();
+        result.m_MatrixElements[2 + 3 * 4] = translation.GetZ();
+
+        return result;
+    }
+
+    constexpr Mat4 Mat4::Scale(const Vec3& scale) noexcept {
+        Mat4 result(1.0f);
+
+        result.m_MatrixElements[0 + 0 * 4] = scale.GetX();
+        result.m_MatrixElements[1 + 1 * 4] = scale.GetY();
+        result.m_MatrixElements[2 + 2 * 4] = scale.GetZ();
+
+        return result;
+    }
+
+    constexpr Mat4 Mat4::Rotation(float angle, const Vec3& axis) noexcept {
+        Mat4 result(1.0f);
+
+        float angleInRadians = Bald::Utils::ToRadians(angle);
+        float x = axis.GetX();
+        float y = axis.GetY();
+        float z = axis.GetZ();
+        float c = static_cast<float>(cos(angleInRadians));
+        float s = static_cast<float>(sin(angleInRadians));
+        float omc = 1 - c;
+
+        result.m_MatrixElements[0 + 0 * 4] = x * x * omc + c;
+        result.m_MatrixElements[1 + 0 * 4] = x * y * omc + z * s;
+        result.m_MatrixElements[2 + 0 * 4] = x * z * omc - y * s;
+
+        result.m_MatrixElements[0 + 1 * 4] = x * y * omc - z * s;
+        result.m_MatrixElements[1 + 1 * 4] = y * y * omc + c;
+        result.m_MatrixElements[2 + 1 * 4] = y * z * omc + x * s;
+
+        result.m_MatrixElements[0 + 2 * 4] = x * z * omc + y * s;
+        result.m_MatrixElements[1 + 2 * 4] = y * z * omc - x * s;
+        result.m_MatrixElements[2 + 2 * 4] = z * z * omc + c;
+
+        return result;
+    }
+
+    constexpr Mat4 Mat4::LookAt(const Vec3& eye, const Vec3& center, const Vec3& up) {
+        Mat4 result(0.0f);
+
+        Vec3 e = eye;
+        Vec3 c = center;
+        Vec3 u = up;
+
+        Vec3 f = c - e;
+        f.Normalize();
+        Vec3 fNorm = f;
+
+        Vec3 r = Vec3::CrossProduct(fNorm, u);
+        r.Normalize();
+        Vec3 rNorm = r;
+
+        Vec3 uNorm = Vec3::CrossProduct(rNorm, fNorm);
+
+        for (int col = 0; col < 3; ++col) {
+            result.m_MatrixElements[0 + col * 4] =  rNorm[col];
+            result.m_MatrixElements[1 + col * 4] =  uNorm[col];
+            result.m_MatrixElements[2 + col * 4] = -fNorm[col];
+        }
+
+        result.m_MatrixElements[0 + 3 * 4] = -Vec3::DotProduct(rNorm, e);
+        result.m_MatrixElements[1 + 3 * 4] = -Vec3::DotProduct(uNorm, e);
+        result.m_MatrixElements[2 + 3 * 4] =  Vec3::DotProduct(fNorm, e);
+        result.m_MatrixElements[3 + 3 * 4] =  1;
+
+        return result;
+    }
+
+    constexpr Mat4 Mat4::OrthogonalProjection(const Vec3& lightSource, const Vec3& normal, float offset) noexcept {
+        Mat4 result(1.0f);
+
+        Vec4 l = Vec4(lightSource[0], lightSource[1], lightSource[2], 1.0f);
+        Vec4 n = Vec4(normal[0], normal[1], normal[2], offset);
+        float alfa = Vec4::DotProduct(n, l);
+
+        result.m_MatrixElements[0 + 0 * 4] = alfa - n[0] * l[0];
+        result.m_MatrixElements[0 + 1 * 4] =      - n[1] * l[0];
+        result.m_MatrixElements[0 + 2 * 4] =      - n[2] * l[0];
+        result.m_MatrixElements[0 + 3 * 4] =      - n[3] * l[0];
+
+        result.m_MatrixElements[1 + 0 * 4] =      - n[0] * l[1];
+        result.m_MatrixElements[1 + 1 * 4] = alfa - n[1] * l[1];
+        result.m_MatrixElements[1 + 2 * 4] =      - n[2] * l[1];
+        result.m_MatrixElements[1 + 3 * 4] =      - n[3] * l[1];
+
+        result.m_MatrixElements[2 + 0 * 4] =      - n[0] * l[2];
+        result.m_MatrixElements[2 + 1 * 4] =      - n[1] * l[2];
+        result.m_MatrixElements[2 + 2 * 4] = alfa - n[2] * l[2];
+        result.m_MatrixElements[2 + 3 * 4] =      - n[3] * l[2];
+
+        result.m_MatrixElements[3 + 0 * 4] =      - n[0] * l[3];
+        result.m_MatrixElements[3 + 1 * 4] =      - n[1] * l[3];
+        result.m_MatrixElements[3 + 2 * 4] =      - n[2] * l[3];
+        result.m_MatrixElements[3 + 3 * 4] = alfa - n[3] * l[3];
+
+        return result;
+    }
+
+    constexpr Mat4 Mat4::Orthographic(float left, float right, float bottom, float top, float near, float far) noexcept {
+        Mat4 result(1.0f);
+
+        result.m_MatrixElements[0 + 0 * 4] = 2.0f / (right - left);
+        result.m_MatrixElements[1 + 1 * 4] = 2.0f / (top - bottom);
+        result.m_MatrixElements[2 + 2 * 4] = 2.0f / (near - far);
+
+        result.m_MatrixElements[0 + 3 * 4] = (right + left) / (left - right);
+        result.m_MatrixElements[1 + 3 * 4] = (top + bottom) / (bottom - top);
+        result.m_MatrixElements[2 + 3 * 4] = (far + near) / (near - far);
+
+        return result;
+    }
+
+    constexpr Mat4 Mat4::Perspective(float fov, float aspectRatio, float near, float far) noexcept {
+        Mat4 result(0.0f);
+
+        float fovInRadians = Bald::Utils::ToRadians(fov);
+        float a = static_cast<float>(tan(fovInRadians / 2.0f));
+        float b = a * aspectRatio;
+
+        result.m_MatrixElements[0 + 0 * 4] = 1.0f / b;
+        result.m_MatrixElements[1 + 1 * 4] = 1.0f / a;
+        result.m_MatrixElements[2 + 2 * 4] = (-near - far) / (near - far);
+        result.m_MatrixElements[2 + 3 * 4] = (2.0f * near * far) / (near - far);
+        result.m_MatrixElements[3 + 2 * 4] = 1.0f;
+
+        return result;
+    }
+
+    constexpr Mat4 Mat4::operator+(const Mat4& other) const noexcept {
+        float newElements[16] = {};
+        for (int i = 0; i < 16; ++i) {
+            newElements[i] = m_MatrixElements[i] + other.m_MatrixElements[i];
+        }
+        return Mat4(newElements);
+    }
+
+    constexpr Mat4 Mat4::operator-(const Mat4& other) const noexcept {
+        return *this + (-1.0f) * other;
+    }
+
+    constexpr Mat4 Mat4::operator*(float scalar) const noexcept {
+        Mat4 result = *this;
+
+        for (int i = 0; i < 16; ++i)
+            result.m_MatrixElements[i] *= scalar;
+
+        return result;
+    }
+
+    constexpr Mat4 Mat4::operator*(const Mat4& other) const noexcept {
+        Mat4 result;
+
+        for (int row = 0; row < 4; ++row)
+            for (int col = 0; col < 4; ++col)
+                result.m_MatrixElements[col + row * 4] = m_MatrixElements[col]      * other.m_MatrixElements[4 * row]     +
+                                                         m_MatrixElements[col + 4]  * other.m_MatrixElements[1 + row * 4] +
+                                                         m_MatrixElements[col + 8]  * other.m_MatrixElements[2 + row * 4] +
+                                                         m_MatrixElements[col + 12] * other.m_MatrixElements[3 + row * 4];
+
+        return result;
+    }
+
+    constexpr Vec4 Mat4::operator*(const Vec4& other) const noexcept {
+        float temp_x = other.GetX();
+        float temp_y = other.GetY();
+        float temp_z = other.GetZ();
+        float temp_w = other.GetW();
+        float x = m_MatrixElements[0] * temp_x + m_MatrixElements[0 + 1 * 4] * temp_y + m_MatrixElements[0 + 2 * 4] * temp_z + m_MatrixElements[0 + 3 * 4] * temp_w;
+        float y = m_MatrixElements[1] * temp_x + m_MatrixElements[1 + 1 * 4] * temp_y + m_MatrixElements[1 + 2 * 4] * temp_z + m_MatrixElements[1 + 3 * 4] * temp_w;
+        float z = m_MatrixElements[2] * temp_x + m_MatrixElements[2 + 1 * 4] * temp_y + m_MatrixElements[2 + 2 * 4] * temp_z + m_MatrixElements[2 + 3 * 4] * temp_w;
+        float w = m_MatrixElements[3] * temp_x + m_MatrixElements[3 + 1 * 4] * temp_y + m_MatrixElements[3 + 2 * 4] * temp_z + m_MatrixElements[3 + 3 * 4] * temp_w;
+
+        return Vec4(x, y, z, w);
+    }
+
+    constexpr Vec4 Mat4::operator*(const Vec3& other) const noexcept {
+        return *this * Vec4(other.GetX(), other.GetY(), other.GetZ(), 1.0f);
+    }
+
+    constexpr bool Mat4::operator==(const Mat4& other) const noexcept {
+        for(int i = 0; i < 16; ++i)
+            if(m_MatrixElements[i] != other.m_MatrixElements[i])
+                return false;
+        return true;
+    }
+
+    constexpr bool Mat4::operator!=(const Mat4& other) const noexcept {
+        return !(*this==other);
+    }
+
+    constexpr Mat4& Mat4::operator+=(const Mat4& other) noexcept {
+        return *this = *this + other;
+    }
+
+    constexpr Mat4& Mat4::operator-=(const Mat4& other) noexcept {
+        return *this = *this - other;
+    }
+
+    constexpr Mat4& Mat4::operator*=(float scalar) noexcept {
+        return *this = *this * scalar;
+    }
+
+    constexpr Mat4& Mat4::operator*=(const Mat4& other) noexcept {
+        return *this = *this * other;
+    }
+
+    constexpr Mat4 operator*(float scalar, const Mat4& other) noexcept {
+        return other * scalar;
+    }
+
+    constexpr const Vec4& Mat4::operator[](int index) const noexcept {
+        return m_MatrixColumns[index];
+    }
+
+}
+// END OF NAMESPACE Bald::Math

--- a/src/math/math.h
+++ b/src/math/math.h
@@ -1,0 +1,10 @@
+//
+// Created by blinku on 07.02.19.
+//
+
+#pragma once
+
+#include "vec2.h"
+#include "vec3.h"
+#include "vec4.h"
+#include "mat4.h"

--- a/src/math/vec2.cpp
+++ b/src/math/vec2.cpp
@@ -1,0 +1,22 @@
+//
+// Created by blinku on 07.02.19.
+//
+
+#include "vec2.h"
+
+namespace Bald::Math {
+
+    Vec2 Vec2::MakeUnitVec(const Vec2& vec) noexcept {
+        float len = vec.Length();
+        if(len != 0)
+            return Vec2(vec.GetX() / len, vec.GetY() / len);
+        CORE_LOG_WARN("[Vec2] Cannot make unit vector from zero vector!");
+        return Vec2(0.0f, 0.0f);
+    }
+
+    std::ostream& operator<<(std::ostream& out, const Vec2& vec) noexcept {
+        out << "[" << vec.m_X << ", " << vec.m_Y << "]\n";
+        return out;
+    }
+
+}

--- a/src/math/vec2.h
+++ b/src/math/vec2.h
@@ -7,6 +7,11 @@
 #include <iostream>
 #include "pch.h"
 
+/**
+ * @class Vec2
+ * @brief vector 2 class
+ */
+
 namespace Bald::Math {
 
     class Vec2 {
@@ -132,7 +137,7 @@ namespace Bald::Math {
          * @return [bool]               true  - vectors are     the same
          *                              false - vectors are NOT the same
          */
-        constexpr bool operator==(const Vec2& other) const noexcept;
+        [[nodiscard]] constexpr bool operator==(const Vec2& other) const noexcept;
 
         /**
          * @fn                          operator!=
@@ -141,7 +146,15 @@ namespace Bald::Math {
          * @return [bool]               true  - vectors are NOT the same
          *                              false - vectors are     the same
          */
-        constexpr bool operator!=(const Vec2& other) const noexcept;
+        [[nodiscard]] constexpr bool operator!=(const Vec2& other) const noexcept;
+
+        /**
+         * @fn                          operator[]
+         * @brief                       returns number in vector at certain index
+         * @param [int]                 index -> index of a number which you want to retrieve
+         * @return [const float&]       float at given index
+         */
+        [[nodiscard]] constexpr const float& operator[](int index) const noexcept;
 
         /**
          * @fn                          operator<<
@@ -170,14 +183,6 @@ namespace Bald::Math {
         float m_X;
         float m_Y;
     }; // END OF CLASS Vec2
-
-        Vec2 Vec2::MakeUnitVec(const Vec2& vec) noexcept {
-                float len = vec.Length();
-                if(len != 0)
-                    return Vec2(vec.GetX() / len, vec.GetY() / len);
-                CORE_LOG_WARN("[Vec2] Cannot make unit vector from zero vector!");
-                return Vec2(0.0f, 0.0f);
-        }
 
         constexpr void Vec2::Normalize() noexcept {
                 float len = Length();
@@ -248,9 +253,16 @@ namespace Bald::Math {
                 return !(*this == other);
         }
 
-        std::ostream& operator<<(std::ostream& out, const Vec2& vec) noexcept {
-                out << "[" << vec.m_X << ", " << vec.m_Y << "]\n";
-                return out;
+        constexpr const float& Vec2::operator[](int index) const noexcept {
+            switch(index) {
+                case 0:
+                    return m_X;
+                case 1:
+                    return m_Y;
+                default:
+                    assert(false);
+                    break;
+            }
         }
 
 }

--- a/src/math/vec3.cpp
+++ b/src/math/vec3.cpp
@@ -1,0 +1,22 @@
+//
+// Created by blinku on 07.02.19.
+//
+
+#include "vec3.h"
+
+namespace Bald::Math {
+
+    Vec3 Vec3::MakeUnitVec(const Vec3& vec) noexcept {
+        float len = vec.Length();
+        if(len != 0)
+            return Vec3(vec.GetX() / len, vec.GetY() / len, vec.GetZ() / len);
+        CORE_LOG_WARN("[Vec3] Cannot make unit vector from zero vector!");
+        return Vec3(0.0f, 0.0f, 0.0f);
+    }
+
+    std::ostream& operator<<(std::ostream& out, const Vec3& vec) noexcept {
+        out << "[" << vec.m_X << ", " << vec.m_Y << ", " << vec.m_Z << "]\n";
+        return out;
+    }
+
+}

--- a/src/math/vec3.h
+++ b/src/math/vec3.h
@@ -7,6 +7,11 @@
 #include <iostream>
 #include "pch.h"
 
+/**
+ * @class Vec3
+ * @brief vector 3 class
+ */
+
 namespace Bald::Math {
     class Vec3 {
     public:
@@ -149,7 +154,7 @@ namespace Bald::Math {
          * @return [bool]               true  - vectors are     the same
          *                              false - vectors are NOT the same
          */
-        constexpr bool operator==(const Vec3& other) const noexcept;
+        [[nodiscard]] constexpr bool operator==(const Vec3& other) const noexcept;
 
         /**
          * @fn                          operator!=
@@ -158,7 +163,15 @@ namespace Bald::Math {
          * @return [bool]               true  - vectors are NOT the same
          *                              false - vectors are     the same
          */
-        constexpr bool operator!=(const Vec3& other) const noexcept;
+        [[nodiscard]] constexpr bool operator!=(const Vec3& other) const noexcept;
+
+        /**
+         * @fn                          operator[]
+         * @brief                       returns number in vector at certain index
+         * @param [int]                 index -> index of a number which you want to retrieve
+         * @return [const float&]       float at given index
+         */
+        [[nodiscard]] constexpr const float& operator[](int index) const noexcept;
 
         /**
          * @fn                          operator<<
@@ -195,15 +208,6 @@ namespace Bald::Math {
         float m_Y;
         float m_Z;
     }; // END OF CLASS VEC3
-
-
-        Vec3 Vec3::MakeUnitVec(const Vec3& vec) noexcept {
-                float len = vec.Length();
-                if(len != 0)
-                    return Vec3(vec.GetX() / len, vec.GetY() / len, vec.GetZ() / len);
-                CORE_LOG_WARN("[Vec3] Cannot make unit vector from zero vector!");
-                return Vec3(0.0f, 0.0f, 0.0f);
-        }
 
         constexpr void Vec3::Normalize() noexcept {
                 float len = Length();
@@ -290,9 +294,18 @@ namespace Bald::Math {
                 return !(*this == other);
         }
 
-        std::ostream& operator<<(std::ostream& out, const Vec3& vec) noexcept {
-                out << "[" << vec.m_X << ", " << vec.m_Y << ", " << vec.m_Z << "]\n";
-                return out;
+        constexpr const float& Vec3::operator[](int index) const noexcept {
+            switch(index) {
+                case 0:
+                    return m_X;
+                case 1:
+                    return m_Y;
+                case 2:
+                    return m_Z;
+                default:
+                    assert(false);
+                    break;
+            }
         }
 
 } // END OF NAMESPACE Bald::Math

--- a/src/math/vec4.cpp
+++ b/src/math/vec4.cpp
@@ -1,0 +1,21 @@
+//
+// Created by blinku on 07.02.19.
+//
+
+#include "vec4.h"
+
+namespace Bald::Math {
+    Vec4 Vec4::MakeUnitVec(const Vec4& vec) noexcept {
+        float len = vec.Length();
+        if(len != 0)
+            return Vec4(vec.GetX() / len, vec.GetY() / len, vec.GetZ() / len, vec.GetW() / len);
+        CORE_LOG_WARN("[Vec4] Cannot make unit vector from zero vector!");
+        return Vec4(0.0f, 0.0f, 0.0f, 0.0f);
+    }
+
+    std::ostream& operator<<(std::ostream& out, const Vec4& vec) noexcept {
+        out << "[" << vec.m_X << ", " << vec.m_Y << ", " << vec.m_Z << ", " << vec.m_W << "]\n";
+        return out;
+    }
+
+}

--- a/src/math/vec4.h
+++ b/src/math/vec4.h
@@ -7,6 +7,11 @@
 #include <iostream>
 #include "pch.h"
 
+/**
+ * @class Vec4
+ * @brief vector 4 class
+ */
+
 namespace Bald::Math {
     class Vec4 {
     public:
@@ -35,6 +40,12 @@ namespace Bald::Math {
          *                              (divides each component by the length of the vector)
          */
         constexpr void Normalize() noexcept;
+
+        /**
+         * @fn                          Homogenize
+         * @brief                       homogenizes vector (divides all of its components by m_W, so that w = 1.0f or sets m_W = 1.0f)
+         */
+        constexpr void Homogenize() noexcept;
 
         /**
         * @fn                          MakeReverseVec
@@ -132,7 +143,7 @@ namespace Bald::Math {
          * @return [bool]               true  - vectors are     the same
          *                              false - vectors are NOT the same
          */
-        constexpr bool operator==(const Vec4& other) const noexcept;
+        [[nodiscard]] constexpr bool operator==(const Vec4& other) const noexcept;
 
         /**
          * @fn                          operator!=
@@ -141,7 +152,15 @@ namespace Bald::Math {
          * @return [bool]               true  - vectors are NOT the same
          *                              false - vectors are     the same
          */
-        constexpr bool operator!=(const Vec4& other) const noexcept;
+        [[nodiscard]] constexpr bool operator!=(const Vec4& other) const noexcept;
+
+        /**
+         * @fn                          operator[]
+         * @brief                       returns number in vector at certain index
+         * @param [int]                 index -> index of a number which you want to retrieve
+         * @return [const float&]       float at given index
+         */
+        [[nodiscard]] constexpr const float& operator[](int index) const noexcept;
 
         /**
          * @fn                          operator<<
@@ -150,7 +169,7 @@ namespace Bald::Math {
          * @param [const Vec4&]         vector object to be printed
          * @return [std::ostream&]      stream
          */
-        [[nodiscard]] friend std::ostream &operator<<(std::ostream& out, const Vec4& vec) noexcept;
+        [[nodiscard]] friend std::ostream& operator<<(std::ostream& out, const Vec4& vec) noexcept;
 
         /**
          * @fn                          GetX
@@ -186,14 +205,6 @@ namespace Bald::Math {
         float m_W;
     }; // END OF CLASS Vec4
 
-        Vec4 Vec4::MakeUnitVec(const Vec4& vec) noexcept {
-                float len = vec.Length();
-                if(len != 0)
-                    return Vec4(vec.GetX() / len, vec.GetY() / len, vec.GetZ() / len, vec.GetW() / len);
-                CORE_LOG_WARN("[Vec4] Cannot make unit vector from zero vector!");
-                return Vec4(0.0f, 0.0f, 0.0f, 0.0f);
-        }
-
         constexpr void Vec4::Normalize() noexcept {
                 float len = Length();
                 if (len != 0) {
@@ -202,6 +213,13 @@ namespace Bald::Math {
                         m_Z /= len;
                         m_W /= len;
                 }
+        }
+
+        constexpr void Vec4::Homogenize() noexcept {
+                if (m_W != 0)
+                    *this *= 1.0f/m_W;
+                else
+                    m_W = 1.0f;
         }
 
         constexpr Vec4 Vec4::MakeReverseVec(const Vec4& vec) noexcept {
@@ -273,9 +291,19 @@ namespace Bald::Math {
                 return !(*this == other);
         }
 
-        std::ostream& operator<<(std::ostream& out, const Vec4& vec) noexcept {
-                out << "[" << vec.m_X << ", " << vec.m_Y << ", " << vec.m_Z << ", " << vec.m_W << "]\n";
-                return out;
+        constexpr const float& Vec4::operator[](int index) const noexcept {
+                switch(index) {
+                    case 0:
+                        return m_X;
+                    case 1:
+                        return m_Y;
+                    case 2:
+                        return m_Z;
+                    case 3:
+                        return m_W;
+                    default:
+                        assert(false);
+                        break;
+                }
         }
-
 } // END OF NAMESPACE Bald::Math

--- a/src/pch.h
+++ b/src/pch.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <iostream>
+#include <array>
 #include <vector>
 #include <string>
 #include <sstream>

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -1,0 +1,15 @@
+//
+// Created by blinku on 09.02.19.
+//
+
+#pragma once
+
+namespace Bald::Utils {
+    constexpr float ToRadians(float angleInDegrees) {
+        return angleInDegrees / 180.0f * static_cast<float>(M_PI);
+    }
+
+    constexpr float ToDegrees(float angleInRadians) {
+        return angleInRadians / static_cast<float>(M_PI) * 180.0f;
+    }
+}

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -1,0 +1,14 @@
+//
+// Created by blinku on 09.02.19.
+//
+
+#pragma once
+
+namespace Bald::Utils {
+    template<typename T>
+    constexpr void ConstexprSwap(T& first, T& second) {
+        T copy = first;
+        first = second;
+        second = copy;
+    }
+}

--- a/tests/test_mat4.cpp
+++ b/tests/test_mat4.cpp
@@ -1,0 +1,250 @@
+//
+// Created by blinku on 07.02.19.
+//
+
+#include "pch.h"
+#include "gtest/gtest.h"
+#include "math.h"
+
+TEST(Determinant, Mat4_Det) {
+    float data[] = {3.0f, 4.0f, 3.0f, 9.0f, 2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 1.0f, 2.0f, 3.0f, 1.0f, 2.0f, 1.0f, 1.0f};
+    Bald::Math::Mat4 A(data);
+
+    ASSERT_FLOAT_EQ(24.0f, A.Det());
+}
+
+TEST(Transpose, Mat4_Transpose) {
+    float data[] = {3.0f, 4.0f, 3.0f, 9.0f, 2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 1.0f, 2.0f, 3.0f, 1.0f, 2.0f, 1.0f, 1.0f};
+    float transposedData[] = {3.0f, 2.0f, 0.0f, 1.0f, 4.0f, 0.0f, 1.0f, 2.0f, 3.0f, 0.0f, 2.0f, 1.0f, 9.0f, 2.0f, 3.0f, 1.0f};
+
+    Bald::Math::Mat4 A(data);
+    A.Transpose();
+
+    EXPECT_EQ(Bald::Math::Mat4(transposedData), A);
+}
+
+TEST(Transpose, Mat4_StaticTranspose) {
+    float data[] = {3.0f, 4.0f, 3.0f, 9.0f, 2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 1.0f, 2.0f, 3.0f, 1.0f, 2.0f, 1.0f, 1.0f};
+    float transposedData[] = {3.0f, 2.0f, 0.0f, 1.0f, 4.0f, 0.0f, 1.0f, 2.0f, 3.0f, 0.0f, 2.0f, 1.0f, 9.0f, 2.0f, 3.0f, 1.0f};
+
+    Bald::Math::Mat4 A(data);
+
+    EXPECT_EQ(Bald::Math::Mat4(transposedData), Bald::Math::Mat4::Transpose(A));
+}
+
+TEST(Inverse, Mat4_Inverse) {
+    float data[] = {1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+    float q = 1.0f/4.0f;
+    float inversedData[] = {q, q, q, -q, q, q, -q, q, q, -q, q, q, -q, q, q, q,};
+
+    Bald::Math::Mat4 A(data);
+    A.Inverse();
+
+    EXPECT_EQ(Bald::Math::Mat4(inversedData), A);
+}
+
+TEST(Inverse, Mat4_StaticInverse) {
+    float data[] = {1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+    float q = 1.0f/4.0f;
+    float inversedData[] = {q, q, q, -q, q, q, -q, q, q, -q, q, q, -q, q, q, q,};
+
+    Bald::Math::Mat4 A(data);
+
+    EXPECT_EQ(Bald::Math::Mat4(inversedData), Bald::Math::Mat4::Inverse(A));
+}
+
+TEST(Inverse, Mat4_ZeroDetInverse) {
+    Bald::Math::Mat4 A(0.0f);
+
+    A.Inverse();
+
+    ASSERT_FLOAT_EQ(1.0f, A.Det());
+}
+
+TEST(Identity, Mat4_Identity) {
+    float data[] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+
+    Bald::Math::Mat4 A(data);
+
+    EXPECT_EQ(A, Bald::Math::Mat4::Identity());
+}
+
+
+TEST(Translation, Mat4_Translation) {
+    Bald::Math::Mat4 A = Bald::Math::Mat4::Translation(Bald::Math::Vec3(2.0f, 3.0f, 1.0f));
+    Bald::Math::Vec3 vec(1.0f, 1.0f, 1.0f);
+
+    Bald::Math::Vec4 translatedVec = A * vec;
+
+    EXPECT_EQ(Bald::Math::Vec4(3.0f, 4.0f, 2.0f, 1.0f), translatedVec);
+}
+
+TEST(Scale, Mat4_Scale) {
+    Bald::Math::Mat4 A = Bald::Math::Mat4::Scale(Bald::Math::Vec3(3.0, 3.0f, 1.0f));
+    Bald::Math::Vec3 vec(1.0f, 1.0f, 1.0f);
+
+    Bald::Math::Vec4 scaledVec = A * vec;
+
+    EXPECT_EQ(Bald::Math::Vec4(3.0f, 3.0f, 1.0f, 1.0f), scaledVec);
+}
+
+TEST(Rotation, Mat4_Rotation) {
+    Bald::Math::Mat4 A = Bald::Math::Mat4::Rotation(90.0f, Bald::Math::Vec3(0.0f, 0.0f, 1.0f));
+    Bald::Math::Vec3 vec(5.0f, 1.0f, 0.0f);
+
+    Bald::Math::Vec4 rotatedVec = A * vec;
+
+    EXPECT_FLOAT_EQ(-1.0f, rotatedVec.GetX());
+    EXPECT_FLOAT_EQ( 5.0f, rotatedVec.GetY());
+    EXPECT_FLOAT_EQ( 0.0f, rotatedVec.GetZ());
+    EXPECT_FLOAT_EQ( 1.0f, rotatedVec.GetW());
+}
+
+TEST(OrthogonalProjection, Mat4_OrthogonalProjection) {
+    Bald::Math::Vec3 lightSource(0.0f, 10.0f, 0.0f);
+    Bald::Math::Vec3 normal(0.0f, 1.0f, 0.0f);
+    float offset = 0.0f;
+
+    Bald::Math::Mat4 A = Bald::Math::Mat4::OrthogonalProjection(lightSource, normal, offset);
+
+    Bald::Math::Vec4 outcome = A * Bald::Math::Vec3(5.0f, 5.0f, 0.0f);
+    outcome.Homogenize();
+
+    EXPECT_TRUE(outcome == Bald::Math::Vec4(10.0f, 0.0f, 0.0f, 1.0f));
+}
+
+TEST(Orthographic, Mat4_Orthographic) {
+    Bald::Math::Mat4 A = Bald::Math::Mat4::Orthographic(-1.0f, 1.0f, -1.0f, 1.0f, -1.0f, 1.0f);
+    float correctOrthographicData[] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+    Bald::Math::Mat4 B(correctOrthographicData);
+
+    EXPECT_TRUE(A == B);
+}
+
+TEST(Perspective, Mat4_Perspective) {
+    Bald::Math::Mat4 A = Bald::Math::Mat4::Orthographic(-1.0f, 1.0f, -1.0f, 1.0f, -1.0f, 1.0f);
+    float correctOrthographicData[] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+    Bald::Math::Mat4 B(correctOrthographicData);
+
+    EXPECT_TRUE(A == B);
+}
+
+TEST(Addition, Mat4_Add) {
+    Bald::Math::Mat4 A(2.0f);
+    Bald::Math::Mat4 B(3.0f);
+
+    Bald::Math::Mat4 C = A + B;
+
+    EXPECT_EQ(Bald::Math::Mat4(5.0f), C);
+}
+
+TEST(Subtraction, Mat4_Subtract) {
+    Bald::Math::Mat4 A(2.0f);
+    Bald::Math::Mat4 B(3.0f);
+
+    Bald::Math::Mat4 C = A - B;
+
+    EXPECT_EQ(Bald::Math::Mat4(-1.0f), C);
+}
+
+TEST(Multiplication, Mat4_MultiplyByScalar) {
+    float dataA[] = {1.0f, 3.0f, 0.0f, 10.0f, 6.0f, 1.0f, 0.0f, 2.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f};
+    float scalar = 5.0f;
+    Bald::Math::Mat4 A(dataA);
+    A = A * scalar;
+
+    float dataB[] = {5.0f, 15.0f, 0.0f, 50.0f, 30.0f, 5.0f, 0.0f, 10.0f, 0.0f, 0.0f, 15.0f, 0.0f, 0.0f, 5.0f, 0.0f, 0.0f};
+    Bald::Math::Mat4 B(dataB);
+
+    EXPECT_EQ(A, B);
+}
+
+TEST(Multiplication, Mat4_MultiplyByMatrix) {
+    float dataA[] = {1.0f, 3.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f};
+    float dataB[] = {0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 1.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 9.0f};
+    float dataC[] = {0.0f, 0.0f, 3.0f, 0.0f, 2.0f, 6.0f, 3.0f, 0.0f, 0.0f, 3.0f, 0.0f, 6.0f, 0.0f, 9.0f, 0.0f, 0.0f};
+    Bald::Math::Mat4 A(dataA);
+    Bald::Math::Mat4 B(dataB);
+
+    Bald::Math::Mat4 C(dataC);
+
+    EXPECT_EQ(C, A * B);
+}
+
+TEST(Multiplication, Mat4_MultiplyByVec4) {
+    float dataA[] = {1.0f, 3.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f};
+    Bald::Math::Mat4 A(dataA);
+    Bald::Math::Vec4 vec(2.0f, 1.0f, 3.0f, 4.0f);
+
+
+    EXPECT_EQ(Bald::Math::Vec4(2.0f, 11.0f, 9.0f, 2.0f), A * vec);
+}
+
+TEST(Multiplication, Mat4_MultiplyByVec3) {
+    float dataA[] = {1.0f, 3.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f};
+    Bald::Math::Mat4 A(dataA);
+    Bald::Math::Vec3 vec(2.0f, 1.0f, 3.0f);
+
+
+    EXPECT_EQ(Bald::Math::Vec4(2.0f, 8.0f, 9.0f, 2.0f), A * vec);
+}
+
+TEST(Operator, Mat4_BoolOperatorTrue) {
+    Bald::Math::Mat4 A(5.0f);
+    Bald::Math::Mat4 B(5.0f);
+
+    EXPECT_TRUE(A == B);
+}
+
+TEST(Operator, Mat4_BoolOperatorFalse) {
+    Bald::Math::Mat4 A(5.0f);
+    Bald::Math::Mat4 B(4.0f);
+
+    EXPECT_FALSE(A == B);
+}
+
+TEST(Operator, Mat4_NotBoolOperatorTrue) {
+    Bald::Math::Mat4 A(5.0f);
+    Bald::Math::Mat4 B(4.0f);
+
+    EXPECT_TRUE(A != B);
+}
+
+TEST(Operator, Mat4_NotBoolOperatorFalse) {
+    Bald::Math::Mat4 A(4.0f);
+    Bald::Math::Mat4 B(4.0f);
+
+    EXPECT_FALSE(A != B);
+}
+
+TEST(Operator, Mat4_MultiplyEqualsOperator) {
+    float dataA[] = {1.0f, 3.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f};
+    float dataB[] = {0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 1.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 9.0f};
+    float dataC[] = {0.0f, 0.0f, 3.0f, 0.0f, 2.0f, 6.0f, 3.0f, 0.0f, 0.0f, 3.0f, 0.0f, 6.0f, 0.0f, 9.0f, 0.0f, 0.0f};
+    Bald::Math::Mat4 A(dataA);
+    Bald::Math::Mat4 B(dataB);
+
+    Bald::Math::Mat4 C(dataC);
+
+    EXPECT_EQ(C, A*=B);
+}
+
+TEST(Operator, Mat4_MultiplyEqualsScalarOperator) {
+    float dataA[] = {1.0f, 3.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f};
+    float dataB[] = {5.0f, 15.0f, 0.0f, 0.0f, 0.0f, 5.0f, 0.0f, 10.0f, 0.0f, 0.0f, 15.0f, 0.0f, 0.0f, 5.0f, 0.0f, 0.0f};
+    float scalar = 5.0f;
+    Bald::Math::Mat4 A(dataA);
+    Bald::Math::Mat4 B(dataB);
+
+    EXPECT_EQ(B, A*=scalar);
+}
+
+TEST(Operator, Mat4_MultiplyScalarMatrixOperator) {
+    float dataA[] = {1.0f, 3.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 0.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f};
+    float dataB[] = {5.0f, 15.0f, 0.0f, 0.0f, 0.0f, 5.0f, 0.0f, 10.0f, 0.0f, 0.0f, 15.0f, 0.0f, 0.0f, 5.0f, 0.0f, 0.0f};
+    float scalar = 5.0f;
+    Bald::Math::Mat4 A(dataA);
+    Bald::Math::Mat4 B(dataB);
+
+    EXPECT_EQ(B, scalar * A);
+}

--- a/tests/test_vector2.cpp
+++ b/tests/test_vector2.cpp
@@ -4,8 +4,7 @@
 
 #include "pch.h"
 #include "gtest/gtest.h"
-#include "math/vec2.h"
-
+#include "math.h"
 
 TEST(Getter, Vec2_GetX) { //NOLINT
     Bald::Math::Vec2 A(66.0f, 3.4f);
@@ -13,13 +12,11 @@ TEST(Getter, Vec2_GetX) { //NOLINT
     ASSERT_FLOAT_EQ(66.0f, A.GetX());
 }
 
-
 TEST(Getter, Vec2_GetY) { //NOLINT
     Bald::Math::Vec2 A(2.0f, -23.33f);
 
     ASSERT_FLOAT_EQ(-23.33f, A.GetY());
 }
-
 
 TEST(NormalizeVector, Vec2_StaticUnitVec) { //NOLINT
     Bald::Math::Vec2 A = Bald::Math::Vec2::MakeUnitVec(Bald::Math::Vec2(3.0f, 4.0f));
@@ -33,7 +30,6 @@ TEST(NormalizeVector, Vec2_StaticUnitZeroVec) { //NOLINT
     EXPECT_EQ(Bald::Math::Vec2(0.0f, 0.0f), A);
 }
 
-
 TEST(NormalizeVector, Vec2_UnitVecMethod) { //NOLINT
     Bald::Math::Vec2 A(5.0f, 12.0f);
 
@@ -42,7 +38,6 @@ TEST(NormalizeVector, Vec2_UnitVecMethod) { //NOLINT
     ASSERT_FLOAT_EQ(1.0f, A.Length());
 }
 
-
 TEST(Operator, Vec2_AddingOperator) { //NOLINT
     Bald::Math::Vec2 A(2.0f, -4.0f);
     Bald::Math::Vec2 B(1.0f, 3.0f);
@@ -50,14 +45,12 @@ TEST(Operator, Vec2_AddingOperator) { //NOLINT
     EXPECT_EQ(Bald::Math::Vec2(3.0f, -1.0f), A + B);
 }
 
-
 TEST(Operator, Vec2_SubtractingOperator) { //NOLINT
     Bald::Math::Vec2 A(2.0f, -4.0f);
     Bald::Math::Vec2 B(1.0f, 3.0f);
 
     EXPECT_EQ(Bald::Math::Vec2(1.0f, -7.0f), A - B);
 }
-
 
 TEST(Operator, Vec2_MultiplyingOperator) { //NOLINT
     Bald::Math::Vec2 A(2.0f, -4.0f);

--- a/tests/test_vector3.cpp
+++ b/tests/test_vector3.cpp
@@ -4,7 +4,7 @@
 
 #include "pch.h"
 #include "gtest/gtest.h"
-#include "math/vec3.h"
+#include "math.h"
 
 TEST(Getter, Vec3_GetX) { //NOLINT
     Bald::Math::Vec3 A(66.0f, 3.4f, 1.0f);

--- a/tests/test_vector4.cpp
+++ b/tests/test_vector4.cpp
@@ -3,7 +3,7 @@
 //
 #include "pch.h"
 #include "gtest/gtest.h"
-#include "math/vec4.h"
+#include "math.h"
 
 TEST(Getter, Vec4_GetX) { //NOLINT
     Bald::Math::Vec4 A(66.0f, 3.4f, 1.0f, 17.0f);


### PR DESCRIPTION
* Started matrix 4x4 implementation.

* Some more implementation.

* Multiple definition error. Push for checking purposes.

* Implemented Mat4 class. Added [[nodiscard]] to operator== and operator!= in Vec2, Vec3, Vec4 classes. Added math.h for ease of use.

* Changed C-like array to std::array in Mat4 class, wrote Translation, Scale, Rotation matrices tests and improved some little stuff as well.

* Few improvements.

* Simplified few things and wrote multiply by a scalar method with corresponding operators + tests.

* Added math_utils.h and utils.h and simplified few more things in Mat4 class.

* Implemented operator[] in all vector classes for use with Mat4 class. Added union in Mat4 to represent data in with either array of floats or array of Vec4s (columns).

* Added orthogonal projection matrix and LookAt matrix implementations. Also added Homogenize() method in Vec4.

* Removed java-like methods. All arithmetic is now implemented inside operators.